### PR TITLE
Replaced user-level Discord with system-level Vesktop

### DIFF
--- a/configuration.nix
+++ b/configuration.nix
@@ -11,6 +11,7 @@
       ./system/hardware/nvidia.nix
       ./system/app/steam.nix
       ./system/app/gamemode.nix
+      ./system/app/vesktop.nix
     ];
 
   # Enable nvidia drivers
@@ -21,6 +22,9 @@
 
   # Enable feral gamemode
   gamemode.enable = true;
+
+  # Enable discord (replacement)
+  vesktop.enable = true;
 
   # Bootloader.
   boot.loader.systemd-boot.enable = true;

--- a/home.nix
+++ b/home.nix
@@ -81,9 +81,12 @@
   chromium.enable = true;
 
   # Set up Discord
-  discord.enable = true;
+
+  # Only enable the next lines if vesktop is not enabled in the system config
+
+  # discord.enable = true;
   # Disable the next line when updating Discord
-  discord.useVencord = true;
+  # discord.useVencord = true;
 
   # tmux configuration
   tmux.enable = true;

--- a/system/app/vesktop.nix
+++ b/system/app/vesktop.nix
@@ -1,0 +1,23 @@
+# Configuration file that sets up the Discord client
+
+{ config, home, lib, pkgs, ... }:
+
+let
+  cfg = config.vesktop;
+in
+{
+  options.vesktop = {
+    enable
+      = lib.mkEnableOption "enable vesktop (discord replacement)";
+  };
+
+  config = lib.mkIf cfg.enable {
+    nixpkgs.config.allowUnfreePredicate = pkg:
+      builtins.elem (lib.getName pkg) [
+        "vesktop"
+      ];
+    environment.systemPackages = [
+      pkgs.vesktop
+    ];
+  };
+}


### PR DESCRIPTION
- Removed user-level Discord 
- Added system-level Vesktop (discord replacement that enables screen share in Wayland + uses Vencord by default)